### PR TITLE
Add FocusService to centralise view focus

### DIFF
--- a/docs/progress/2025-07-10_17-15-35_CodeGen-CSharp.md
+++ b/docs/progress/2025-07-10_17-15-35_CodeGen-CSharp.md
@@ -1,0 +1,8 @@
+### FocusService introduced
+*Timestamp:* 2025-07-10T17:15:35Z
+*Files touched:* src/Services/IFocusService.cs, src/Services/FocusService.cs, src/Views/InvoiceParts/InvoiceSidebar.xaml.cs, src/Views/InvoiceParts/InvoiceHeader.xaml.cs, src/Views/InvoiceParts/InvoiceSummary.xaml.cs, src/Views/Lookup/LookupDialog.xaml.cs, src/Infrastructure/AppContext.cs
+*Summary:* Added centralized service to manage initial focus from ViewModels and views.
+*Details:*
+- Implemented IFocusService and FocusService with control focusing logic.
+- Registered service in DI container.
+- Views now call SetInitialFocus on Loaded, removing direct Focus() calls.

--- a/docs/progress/2025-07-10_17-15-35_DocWriter.md
+++ b/docs/progress/2025-07-10_17-15-35_DocWriter.md
@@ -1,0 +1,6 @@
+### Document FocusService usage
+*Timestamp:* 2025-07-10T17:15:35Z
+*Files touched:* docs/ui_flow.md
+*Summary:* Described new FocusService and ViewModel interaction.
+*Details:*
+- Updated keyboard & focus logic section with FocusService steps.

--- a/docs/ui_flow.md
+++ b/docs/ui_flow.md
@@ -36,13 +36,14 @@
 ## Keyboard & focus logic
 
 1. A Tab sorrend: Sidebar lista → Header mezők → ItemsGrid → Summary → alsó eszköztár.
-2. Minden új nézetre lépéskor a logikus első mező (Sidebar lista) kap fókuszt. A fókusz a `FocusManager.FocusedElement` beállítással indul az InvoiceList.
-3. A `CommandManagerService` automatikusan hozzáadja az aktuális nézet `IUserCommand` gyorsbillentyűit.
-4. Ctrl+S mentésre, Esc az aktuális sor vagy ablak bezárására szolgál; Esc-sorozat esetén először a szerkesztő, majd a főmenü aktiválódik.
-5. A menüsor Alt-tal, a gombok AccessKey jelöléssel érhetők el; az Enter és Esc útvonal minden dialógusban egységes.
-6. Fontos mezők gyorsbillentyűi: Alt+N – Szállító, Alt+P – Számlaszám, Alt+D – Dátum, Alt+T – Tranzakciószám.
-7. Az OnboardingOverlay megnyitásakor a Bezár gombon van a fókusz.
-8. A szűrő- és beállítóablakok a `FocusManager.FocusedElement` tulajdonsággal jelölik ki az első mezőt.
+2. Minden új nézetre lépéskor a `FocusService` állítja be a logikus első mező fókuszát. A nézetek a `Loaded` eseményben hívják a `SetInitialFocus` metódust.
+3. A ViewModel bármikor hívhatja a `Focus(Control)` metódust, így a fókusz logikája nem kerül a nézetek kód-behindjébe.
+4. A `CommandManagerService` automatikusan hozzáadja az aktuális nézet `IUserCommand` gyorsbillentyűit.
+5. Ctrl+S mentésre, Esc az aktuális sor vagy ablak bezárására szolgál; Esc-sorozat esetén először a szerkesztő, majd a főmenü aktiválódik.
+6. A menüsor Alt-tal, a gombok AccessKey jelöléssel érhetők el; az Enter és Esc útvonal minden dialógusban egységes.
+7. Fontos mezők gyorsbillentyűi: Alt+N – Szállító, Alt+P – Számlaszám, Alt+D – Dátum, Alt+T – Tranzakciószám.
+8. Az OnboardingOverlay megnyitásakor a Bezár gombon van a fókusz.
+9. A szűrő- és beállítóablakok a `FocusManager.FocusedElement` tulajdonsággal jelölik ki az első mezőt.
 
 🧾 Exit & Save flow
 A szerkesztőből kilépés kizárólag az Esc megnyomásával történik.

--- a/src/Infrastructure/AppContext.cs
+++ b/src/Infrastructure/AppContext.cs
@@ -158,6 +158,7 @@ public static class AppContext
         services.AddSingleton<IPriceHistoryService, JsonPriceHistoryService>();
         services.AddSingleton<IStatusService, StatusService>();
         services.AddSingleton<IFeedbackService, FeedbackService>();
+        services.AddSingleton<IFocusService, FocusService>();
         services.AddSingleton<CommandManagerService>();
     }
 

--- a/src/Services/FocusService.cs
+++ b/src/Services/FocusService.cs
@@ -1,0 +1,43 @@
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Wrecept.Infrastructure;
+using Wrecept.Views.InvoiceParts;
+using Wrecept.Views.Lookup;
+
+namespace Wrecept.Services;
+
+public class FocusService : IFocusService
+{
+    public void SetInitialFocus(UserControl view)
+    {
+        switch (view)
+        {
+            case InvoiceSidebar sidebar:
+                if (sidebar.InvoiceList.Items.Count > 0)
+                    sidebar.InvoiceList.SelectedIndex = 0;
+                Focus(sidebar.InvoiceList);
+                break;
+            case InvoiceHeader header:
+                Focus(header.SupplierNameBox.SearchBox);
+                break;
+            case InvoiceSummary summary:
+                Focus(summary.VatGrid);
+                break;
+            case LookupDialog dialog:
+                Focus(dialog.SearchBox);
+                break;
+        }
+    }
+
+    public void Focus(Control control)
+    {
+        control.Dispatcher.InvokeAsync(() =>
+        {
+            if (AppContext.InputLocked)
+                return;
+            control.Focus();
+            if (control is TextBox tb)
+                tb.SelectAll();
+        }, DispatcherPriority.Background);
+    }
+}

--- a/src/Services/IFocusService.cs
+++ b/src/Services/IFocusService.cs
@@ -1,0 +1,9 @@
+namespace Wrecept.Services;
+
+using System.Windows.Controls;
+
+public interface IFocusService
+{
+    void SetInitialFocus(UserControl view);
+    void Focus(Control control);
+}

--- a/src/Views/InvoiceParts/InvoiceHeader.xaml.cs
+++ b/src/Views/InvoiceParts/InvoiceHeader.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Services;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.ViewModels;
@@ -9,16 +11,19 @@ public partial class InvoiceHeader : UserControl
     public InvoiceHeader()
     {
         InitializeComponent();
-        Loaded += (_, _) =>
-        {
-            SupplierNameBox.SearchBox.Focus();
-            AccessKeyManager.Register("N", SupplierNameBox);
-            AccessKeyManager.Register("C", AddressBox);
-            AccessKeyManager.Register("A", TaxNumberBox);
-            AccessKeyManager.Register("P", SerialBox);
-            AccessKeyManager.Register("D", IssueDateBox);
-            AccessKeyManager.Register("M", PaymentMethodBox);
-            AccessKeyManager.Register("T", TransactionBox);
-        };
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        var focus = App.Services.GetRequiredService<IFocusService>();
+        focus.SetInitialFocus(this);
+        AccessKeyManager.Register("N", SupplierNameBox);
+        AccessKeyManager.Register("C", AddressBox);
+        AccessKeyManager.Register("A", TaxNumberBox);
+        AccessKeyManager.Register("P", SerialBox);
+        AccessKeyManager.Register("D", IssueDateBox);
+        AccessKeyManager.Register("M", PaymentMethodBox);
+        AccessKeyManager.Register("T", TransactionBox);
     }
 }

--- a/src/Views/InvoiceParts/InvoiceSidebar.xaml.cs
+++ b/src/Views/InvoiceParts/InvoiceSidebar.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Services;
 using System.Windows.Controls;
 
 
@@ -8,12 +10,7 @@ public partial class InvoiceSidebar : UserControl
     public InvoiceSidebar()
     {
         InitializeComponent();
-        Loaded += (_, _) =>
-        {
-            if (InvoiceList.Items.Count > 0)
-                InvoiceList.SelectedIndex = 0;
-            InvoiceList.Focus();
-        };
+        Loaded += (_, _) => App.Services.GetRequiredService<IFocusService>().SetInitialFocus(this);
     }
 
 }

--- a/src/Views/InvoiceParts/InvoiceSummary.xaml.cs
+++ b/src/Views/InvoiceParts/InvoiceSummary.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Services;
 using System.Windows.Controls;
 
 namespace Wrecept.Views.InvoiceParts;
@@ -7,6 +9,6 @@ public partial class InvoiceSummary : UserControl
     public InvoiceSummary()
     {
         InitializeComponent();
-        Loaded += (_, _) => VatGrid.Focus();
+        Loaded += (_, _) => App.Services.GetRequiredService<IFocusService>().SetInitialFocus(this);
     }
 }

--- a/src/Views/Lookup/LookupDialog.xaml.cs
+++ b/src/Views/Lookup/LookupDialog.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Services;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -8,7 +10,7 @@ public partial class LookupDialog : UserControl
     public LookupDialog()
     {
         InitializeComponent();
-        Loaded += (_, _) => SearchBox.Focus();
+        Loaded += (_, _) => App.Services.GetRequiredService<IFocusService>().SetInitialFocus(this);
     }
 
 }


### PR DESCRIPTION
## Summary
- introduce `IFocusService` and `FocusService`
- register the service in `AppContext`
- call `SetInitialFocus` on view load events instead of manual `Focus()`
- document usage in `ui_flow.md`
- log progress

## Testing
- `dotnet restore Wrecept.sln`
- `dotnet build Wrecept.sln --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff349a7188322bbdec93168c36abe